### PR TITLE
Correct JSON decoding and Add Expired Option

### DIFF
--- a/crtsh.py
+++ b/crtsh.py
@@ -44,6 +44,7 @@ class crtshAPI(object):
             try:
                 content = req.content.decode('utf-8')
                 data = json.loads(content)
+                return data
             except ValueError:
                 # crt.sh fixed their JSON response. This shouldn't be necessary anymore
                 # https://github.com/crtsh/certwatch_db/commit/f4f46ea37c23543c4cdf1a3c8867d68967641807

--- a/crtsh.py
+++ b/crtsh.py
@@ -9,12 +9,14 @@ import requests, json
 class crtshAPI(object):
     """crtshAPI main handler."""
 
-    def search(self, domain, wildcard=True):
+    def search(self, domain, wildcard=True, expired=True):
         """
         Search crt.sh for the given domain.
 
         domain -- Domain to search for
         wildcard -- Whether or not to prepend a wildcard to the domain
+                    (default: True)
+        expired -- Whether or not to include expired certificates
                     (default: True)
 
         Return a list of objects, like so:
@@ -29,8 +31,10 @@ class crtshAPI(object):
         }
         """
         base_url = "https://crt.sh/?q={}&output=json"
-        if wildcard:
-            domain = "%25.{}".format(domain)
+        if not expired:
+            base_url = base_url + "&exclude=expired"
+        if wildcard and "%" not in domain:
+            domain = "%.{}".format(domain)
         url = base_url.format(domain)
 
         ua = 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1'
@@ -39,6 +43,10 @@ class crtshAPI(object):
         if req.ok:
             try:
                 content = req.content.decode('utf-8')
+                data = json.loads(content)
+            except ValueError:
+                # crt.sh fixed their JSON response. This shouldn't be necessary anymore
+                # https://github.com/crtsh/certwatch_db/commit/f4f46ea37c23543c4cdf1a3c8867d68967641807
                 data = json.loads("[{}]".format(content.replace('}{', '},{')))
                 return data
             except Exception as err:


### PR DESCRIPTION
The JSON fix shouldn't be necessary any more after recent changes by crt.sh.
crtsh/certwatch_db@f4f46ea

Added an option to exclude expired certificates. The default is to include expired certificates to keep current functionality.

For wildcard checks, changed the %25 to %, and added a check for wildcards already in the domain query string.
